### PR TITLE
Conditional to stop filtering wp_trim_excerpt

### DIFF
--- a/wpsocialite.php
+++ b/wpsocialite.php
@@ -154,6 +154,8 @@ if (!class_exists("wpsocialite")) {
 
 		function wpsocialite_add_to_content( $content )
 		{
+			global $wp_current_filter;
+  			if(in_array('get_the_excerpt', $wp_current_filter)) return $content;
 
 			$position = get_option('wpsocialite_position');
 


### PR DESCRIPTION
Conditional to check if currently in `get_the_excerpt` to avoid adding socialite markup to automatically generated excerpts (using `wp_trim_excerpt`. Fixes the plaintext `Share on FacebookShare on TwitterShare on Google+` [issue](https://github.com/tmort/wpsocialite/issues/4)

/via..
http://digitalnature.eu/blog/2011/09/12/how-to-correctly-hook-your-filter-to-the-post-content/
