### PR TITLE
Fixing an issue with overlaid box overflow

### DIFF
--- a/lib/wpsocialite.css
+++ b/lib/wpsocialite.css
@@ -19,7 +19,7 @@
  */
 
 
-.wpsocialite.large { display: block; list-style: none; padding: 0; margin: 20px; }
+.wpsocialite.large { display: block; list-style: none; padding: 0; margin: 20px; overflow: visible; }
 .wpsocialite.large > li { display: block; margin: 0; padding: 10px; float: left; }
 .wpsocialite.large .socialite { display: block; position: relative; background: url('social-sprite.png') 0 0 no-repeat; }
 .wpsocialite.large .socialite-loaded { background: none !important; }
@@ -36,7 +36,7 @@
 
 /* .small-load { margin: 0 0 0.625em 0; font-weight: bold; padding: 5px; } */
 
-.wpsocialite.small { display: block; list-style: none; padding: 10px; margin: 10px; }
+.wpsocialite.small { display: block; list-style: none; padding: 10px; margin: 10px; overflow: visible; }
 .wpsocialite.small > li { margin: 0; display:inline; float:left; width:20%; }
 .wpsocialite.small .socialite { display: block; position: relative; width: 150px; height: 30px; background: url('custom-default.png') 0 0 no-repeat; }
 .wpsocialite.small .socialite-loaded { background: none; }


### PR DESCRIPTION
adding  overflow: visible; to .wpsocialite.small, and .wpsocialite.large to fix an issue I was having with the facebook overlaid box cutting off outside of the UL element.

Image attached of the issue.

![Screen Shot 2013-01-25 at 10 46 26 AM](https://f.cloud.github.com/assets/80901/97761/69a01fee-6706-11e2-8995-6822cf9f057f.png)
