### PR TITLE
Adding option to remove the placeholder icons, making icons sit flush to the left

### DIFF
--- a/lib/wpsocialite.css
+++ b/lib/wpsocialite.css
@@ -50,3 +50,6 @@
 .wpsocialite.small .pinterest-pinit { background-position: 0 -175px; }
 .wpsocialite.small .stumbleupon-share { background-position: 0 -225px; }
 .wpsocialite.small .twitter-follow.socialite-loaded{ width:200px; }
+
+
+.wpsocialite.no-icon-on-load .socialite{background:none;}

--- a/lib/wpsocialite.css
+++ b/lib/wpsocialite.css
@@ -19,7 +19,7 @@
  */
 
 
-.wpsocialite.large { display: block; list-style: none; padding: 0; margin: 20px; overflow: visible; }
+.wpsocialite.large { display: block; list-style: none; padding: 0; margin: 20px 20px 20px 0; overflow: visible; }
 .wpsocialite.large > li { display: block; margin: 0; padding: 10px; float: left; }
 .wpsocialite.large .socialite { display: block; position: relative; background: url('social-sprite.png') 0 0 no-repeat; }
 .wpsocialite.large .socialite-loaded { background: none !important; }
@@ -38,7 +38,7 @@
 
 /* .small-load { margin: 0 0 0.625em 0; font-weight: bold; padding: 5px; } */
 
-.wpsocialite.small { display: block; list-style: none; padding: 10px; margin: 10px; overflow: visible; }
+.wpsocialite.small { display: block; list-style: none; padding: 10px 10px 10px 0; margin: 10px 10px 10px 0; overflow: visible; }
 .wpsocialite.small > li { margin: 0; display:inline; float:left; width:20%; }
 .wpsocialite.small .socialite { display: block; position: relative; width: 150px; height: 30px; background: url('custom-default.png') 0 0 no-repeat; }
 .wpsocialite.small .socialite-loaded { background: none; }

--- a/wpsocialite.php
+++ b/wpsocialite.php
@@ -165,7 +165,9 @@ if (!class_exists("wpsocialite")) {
             $value 		= get_option('wpsocialite_networkoptions');
             $buttons 	= self::wpsocialite_list_network_options($postlink, $title, $size, $imagelink);
 
-            $return = '<ul class="wpsocialite social-buttons '.$size.'">';
+            $icon_opt = ( get_option('wpsocialite_iconoptions') == 1 ? ' no-icon-on-load' : '');
+
+            $return = '<ul class="wpsocialite social-buttons '.$size . $icon_opt.'">';
 
 	            foreach ( $buttons as $button ) {
 
@@ -284,6 +286,24 @@ if (!class_exists("wpsocialite")) {
                 )
             );
             register_setting( $option_group = 'discussion', $option_name = 'wpsocialite_mode' );
+
+
+                        add_settings_field(
+                            $id 		= 'wpsocialite_iconoptions',
+                            $title 		= __('Icon Options','wpsocialite'),
+                            $callback 	= array( $this, 'wpsocialite_checkbox' ),
+                            $page 		= 'discussion',
+                            $section 	= 'wpsocialite',
+                            $args       = array(
+            	                'name'        => 'wpsocialite_iconoptions',
+            	                'description' => __('Do not load icons until scroll or hover action occurs.','wpsocialite'),
+            	                'options'     => array(
+                                    '1'     => __('Do not load icons until scroll or hover action occurs.','wpsocialite'),
+            	                ),
+                            )
+                        );
+                        register_setting( $option_group = 'discussion', $option_name = 'wpsocialite_iconoptions' );
+
 
             add_settings_field(
                 $id 		= 'wpsocialite_excerpt',


### PR DESCRIPTION
This came out of a request from a few clients saying that they didn't like the icons loading, then 'flickering' on scroll.
